### PR TITLE
Add IPA pseudo-language interpreter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,89 @@
-<html>
-test.... page..
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>IPA Pseudo-language Interpreter</title>
+<style>
+  body { font-family: sans-serif; margin: 20px; }
+  textarea { width: 100%; height: 200px; }
+  pre { background: #f4f4f4; padding: 10px; }
+</style>
+</head>
+<body>
+<h1 id="title">IPA Pseudo-language Interpreter</h1>
+<label for="lang">Language / 言語:</label>
+<select id="lang">
+  <option value="en">English</option>
+  <option value="ja">日本語</option>
+</select>
+<br/>
+<textarea id="code" placeholder="Enter IPA pseudocode here"></textarea>
+<br/>
+<button id="run">Run</button>
+<pre id="output"></pre>
+<script>
+const translations = {
+  en: {
+    title: "IPA Pseudo-language Interpreter",
+    run: "Run",
+    placeholder: "Enter IPA pseudocode here",
+    output: "Output:"
+  },
+  ja: {
+    title: "IPA準拠 擬似言語インタープリター",
+    run: "実行",
+    placeholder: "ここに擬似言語を入力",
+    output: "出力:"
+  }
+};
+
+function setLanguage(lang) {
+  const t = translations[lang];
+  document.getElementById('title').textContent = t.title;
+  document.getElementById('run').textContent = t.run;
+  document.getElementById('code').placeholder = t.placeholder;
+  document.documentElement.lang = lang;
+}
+
+document.getElementById('lang').addEventListener('change', (e) => {
+  setLanguage(e.target.value);
+});
+
+setLanguage('en');
+
+function evaluateExpression(expr, env) {
+  const replaced = expr.replace(/([A-Za-z_][A-Za-z0-9_]*)/g, (match) => {
+    return Object.prototype.hasOwnProperty.call(env, match) ? env[match] : 0;
+  });
+  try {
+    return Function('"use strict"; return (' + replaced + ');')();
+  } catch (e) {
+    return 0;
+  }
+}
+
+function runCode() {
+  const lines = document.getElementById('code').value.split(/\n/);
+  const env = {};
+  const out = [];
+  for (let line of lines) {
+    line = line.trim();
+    if (!line) continue;
+    let m;
+    if ((m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*(?:<-|←)\s*(.+)$/))) {
+      const [, variable, expr] = m;
+      env[variable] = evaluateExpression(expr, env);
+    } else if ((m = line.match(/^(?:print|出力)\s+(.+)$/))) {
+      out.push(String(evaluateExpression(m[1], env)));
+    } else {
+      out.push('? ' + line);
+    }
+  }
+  const t = translations[document.getElementById('lang').value];
+  document.getElementById('output').textContent = t.output + '\n' + out.join('\n');
+}
+
+document.getElementById('run').addEventListener('click', runCode);
+</script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- implement HTML-based interpreter for IPA-style pseudocode supporting English and Japanese UI
- update page language dynamically when switching languages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fdeec9d4832b8913dd48db3ff221