### PR TITLE
Support return value via '戻り値' assignment

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -266,7 +266,12 @@ function resetInput(){
           const p = s.split('←');
           const lhs = p[0].trim();
           const rhs = convertExpr(p.slice(1).join('←'));
-          push(`${lhs} = ${rhs};`);
+          const lowerLhs = lhs.toLowerCase();
+          if(lhs === '戻り値' || lowerLhs === 'return value' || lowerLhs === 'returnvalue' || lowerLhs === 'return'){
+            push(`return ${rhs};`);
+          } else {
+            push(`${lhs} = ${rhs};`);
+          }
           return;
         }
         // 単一 '=' を代入とみなす（比較演算子を除外）

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -260,7 +260,12 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
           const p = s.split('←');
           const lhs = p[0].trim();
           const rhs = convertExpr(p.slice(1).join('←'));
-          push(`${lhs} = ${rhs};`);
+          const lowerLhs = lhs.toLowerCase();
+          if(lhs === '戻り値' || lowerLhs === 'return value' || lowerLhs === 'returnvalue' || lowerLhs === 'return'){
+            push(`return ${rhs};`);
+          } else {
+            push(`${lhs} = ${rhs};`);
+          }
           return;
         }
         // 単一 '=' を代入とみなす（比較演算子を除外）


### PR DESCRIPTION
## Summary
- Interpret assignments to `戻り値` or `return value` as JavaScript `return` statements
- Apply return-value translation in both browser and worker compilers

## Testing
- `node /tmp/test_return.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc82c09e78832ba13b5e82205b2914