### PR TITLE
Avoid assignments in conditional statements

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -300,7 +300,8 @@ function resetInput(){
         let m;
   
         // レコード定義開始: 「レコード型 T」または「record type T」
-        if(!inRecord && (m=line.match(/^(?:レコード型|record\s+type)\s+([A-Za-z_][A-Za-z0-9_]*)$/i))){
+        m = line.match(/^(?:レコード型|record\s+type)\s+([A-Za-z_][A-Za-z0-9_]*)$/i);
+        if(!inRecord && m){
           inRecord = true;
           currentRecord = m[1];
           recordDefs[currentRecord] = {fields:{}};
@@ -315,7 +316,8 @@ function resetInput(){
         if(inRecord){ const f=parseFieldKind(line); if(f){ recordDefs[currentRecord].fields[f.name]=f.kind; } continue; }
   
         // 手続き（プロシージャ）開始: 「手続き NAME(...)」または「procedure NAME(...)」
-        if(m = line.match(/^(?:手続き|procedure)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i)){
+        m = line.match(/^(?:手続き|procedure)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i);
+        if(m){
           const name = m[1];
           const paramStr = m[2];
           push(`function ${name}(){`);
@@ -329,17 +331,20 @@ function resetInput(){
         }
   
         // 反復(cond)
-        if(m=line.match(/^反復\s*\((.*)\)\s*$/)){ push(`while(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^反復\s*\((.*)\)\s*$/);
+        if(m){ push(`while(${convertExpr(m[1])}){`); continue; }
         if(/^反復終わり\s*$/.test(line)){ push('}'); continue; }
   
         // do … until / repeat … until
         if(/^do\s*$/i.test(line)){ push('do{'); continue; }
         if(/^repeat\s*$/i.test(line)){ push('do{'); continue; }
-        if(m=line.match(/^until\s*\((.*)\)\s*$/i)){ push(`} while(!(${convertExpr(m[1])}));`); continue; }
+        m = line.match(/^until\s*\((.*)\)\s*$/i);
+        if(m){ push(`} while(!(${convertExpr(m[1])}));`); continue; }
   
         // 宣言: 日本語・英語両対応の型宣言 (例: 整数型: x, int: y, integer array: arr[])
         // 型名の部分には空白が含まれる場合があるため、コロンまでをまとめて取得する。
-        if(m = line.match(/^([^:]+)\s*:\s*(.+)$/)){
+        m = line.match(/^([^:]+)\s*:\s*(.+)$/);
+        if(m){
           // 型名をトリムし、小文字化。内部では単語間の複数スペースを1つに揃える。
           const rawType = m[1].trim();
           const tKey = rawType.toLowerCase().replace(/\s+/g, ' ');
@@ -350,7 +355,8 @@ function resetInput(){
           }
         }
         // ポインタ宣言: 「型 ポインタ 変数」または「型 pointer 変数」。型は複数語でもよい。
-        if(m = line.match(/^(.*?)\s*(?:ポインタ|pointer)\s*([A-Za-z_][A-Za-z0-9_]*)$/i)){
+        m = line.match(/^(.*?)\s*(?:ポインタ|pointer)\s*([A-Za-z_][A-Za-z0-9_]*)$/i);
+        if(m){
           const rawType = m[1].trim();
           const T = rawType;
           const v = m[2];
@@ -360,7 +366,8 @@ function resetInput(){
         }
 
         // 入力: 日本語「入力(...)」または英語「input(...)」
-        if(m = line.match(/^(?:入力|input)\s*\((.*)\)\s*$/i)){
+        m = line.match(/^(?:入力|input)\s*\((.*)\)\s*$/i);
+        if(m){
           const vars = m[1].split(',').map(s=>s.trim()).filter(Boolean);
           const sarr = '[' + vars.map(v=>`"${v}"`).join(', ') + ']';
           const tmp = `__tmp_in_${tmpCounter++}`;
@@ -372,7 +379,8 @@ function resetInput(){
         }
 
         // 出力・改行: 日本語「出力」「改行」、英語「output」「newline」
-        if(m = line.match(/^(?:出力|output)\s*\((.*)\)\s*$/i)){
+        m = line.match(/^(?:出力|output)\s*\((.*)\)\s*$/i);
+        if(m){
           push(`__出力(${convertExpr(m[1])});`);
           continue;
         }
@@ -382,12 +390,15 @@ function resetInput(){
         }
   
         // 条件/ループ
-        if(m=line.match(/^if\s*\((.*)\)\s*$/i)){ push(`if(${convertExpr(m[1])}){`); continue; }
-        if(m=line.match(/^elseif\s*\((.*)\)\s*$/i)){ push(`} else if(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^if\s*\((.*)\)\s*$/i);
+        if(m){ push(`if(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^elseif\s*\((.*)\)\s*$/i);
+        if(m){ push(`} else if(${convertExpr(m[1])}){`); continue; }
         if(/^else\s*$/i.test(line)){ push('} else {'); continue; }
         if(/^endif\s*$/i.test(line)){ push('}'); continue; }
   
-        if(m=line.match(/^for\s*\(([^;]+);([^;]+);\s*([^)]+)\)\s*$/i)){
+        m = line.match(/^for\s*\(([^;]+);([^;]+);\s*([^)]+)\)\s*$/i);
+        if(m){
           const init=convertExpr(m[1]).replace(/←/g,'=');
           const cond=convertExpr(m[2]);
           const step=convertExpr(m[3]).replace(/←/g,'=');
@@ -395,7 +406,8 @@ function resetInput(){
         }
         if(/^endfor\s*$/i.test(line)){ push('}'); continue; }
   
-        if(m=line.match(/^while\s*\((.*)\)\s*$/i)){ push(`while(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^while\s*\((.*)\)\s*$/i);
+        if(m){ push(`while(${convertExpr(m[1])}){`); continue; }
         if(/^endwhile\s*$/i.test(line)){ push('}'); continue; }
   
         // 1行に複数文（; 区切り）— forヘッダ以外

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -294,7 +294,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         let m;
   
         // レコード定義開始: 「レコード型 T」または「record type T」
-        if(!inRecord && (m=line.match(/^(?:レコード型|record\s+type)\s+([A-Za-z_][A-Za-z0-9_]*)$/i))){
+        m = line.match(/^(?:レコード型|record\s+type)\s+([A-Za-z_][A-Za-z0-9_]*)$/i);
+        if(!inRecord && m){
           inRecord = true;
           currentRecord = m[1];
           recordDefs[currentRecord] = {fields:{}};
@@ -309,7 +310,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         if(inRecord){ const f=parseFieldKind(line); if(f){ recordDefs[currentRecord].fields[f.name]=f.kind; } continue; }
   
         // 手続き（プロシージャ）開始: 「手続き NAME(...)」または「procedure NAME(...)」
-        if(m = line.match(/^(?:手続き|procedure)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i)){
+        m = line.match(/^(?:手続き|procedure)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i);
+        if(m){
           const name = m[1];
           const paramStr = m[2];
           push(`function ${name}(){`);
@@ -323,17 +325,20 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         }
   
         // 反復(cond)
-        if(m=line.match(/^反復\s*\((.*)\)\s*$/)){ push(`while(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^反復\s*\((.*)\)\s*$/);
+        if(m){ push(`while(${convertExpr(m[1])}){`); continue; }
         if(/^反復終わり\s*$/.test(line)){ push('}'); continue; }
   
         // do … until / repeat … until
         if(/^do\s*$/i.test(line)){ push('do{'); continue; }
         if(/^repeat\s*$/i.test(line)){ push('do{'); continue; }
-        if(m=line.match(/^until\s*\((.*)\)\s*$/i)){ push(`} while(!(${convertExpr(m[1])}));`); continue; }
+        m = line.match(/^until\s*\((.*)\)\s*$/i);
+        if(m){ push(`} while(!(${convertExpr(m[1])}));`); continue; }
   
         // 宣言: 日本語・英語両対応の型宣言 (例: 整数型: x, int: y, integer array: arr[])
         // 型名の部分には空白が含まれる場合があるため、コロンまでをまとめて取得する。
-        if(m = line.match(/^([^:]+)\s*:\s*(.+)$/)){
+        m = line.match(/^([^:]+)\s*:\s*(.+)$/);
+        if(m){
           // 型名をトリムし、小文字化。内部では単語間の複数スペースを1つに揃える。
           const rawType = m[1].trim();
           const tKey = rawType.toLowerCase().replace(/\s+/g, ' ');
@@ -344,7 +349,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
           }
         }
         // ポインタ宣言: 「型 ポインタ 変数」または「型 pointer 変数」。型は複数語でもよい。
-        if(m = line.match(/^(.*?)\s*(?:ポインタ|pointer)\s*([A-Za-z_][A-Za-z0-9_]*)$/i)){
+        m = line.match(/^(.*?)\s*(?:ポインタ|pointer)\s*([A-Za-z_][A-Za-z0-9_]*)$/i);
+        if(m){
           const rawType = m[1].trim();
           const T = rawType;
           const v = m[2];
@@ -354,7 +360,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         }
 
         // 入力: 日本語「入力(...)」または英語「input(...)」
-        if(m = line.match(/^(?:入力|input)\s*\((.*)\)\s*$/i)){
+        m = line.match(/^(?:入力|input)\s*\((.*)\)\s*$/i);
+        if(m){
           const vars = m[1].split(',').map(s=>s.trim()).filter(Boolean);
           const sarr = '[' + vars.map(v=>`"${v}"`).join(', ') + ']';
           const tmp = `__tmp_in_${tmpCounter++}`;
@@ -366,7 +373,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         }
 
         // 出力・改行: 日本語「出力」「改行」、英語「output」「newline」
-        if(m = line.match(/^(?:出力|output)\s*\((.*)\)\s*$/i)){
+        m = line.match(/^(?:出力|output)\s*\((.*)\)\s*$/i);
+        if(m){
           push(`__出力(${convertExpr(m[1])});`);
           continue;
         }
@@ -376,12 +384,15 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         }
   
         // 条件/ループ
-        if(m=line.match(/^if\s*\((.*)\)\s*$/i)){ push(`if(${convertExpr(m[1])}){`); continue; }
-        if(m=line.match(/^elseif\s*\((.*)\)\s*$/i)){ push(`} else if(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^if\s*\((.*)\)\s*$/i);
+        if(m){ push(`if(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^elseif\s*\((.*)\)\s*$/i);
+        if(m){ push(`} else if(${convertExpr(m[1])}){`); continue; }
         if(/^else\s*$/i.test(line)){ push('} else {'); continue; }
         if(/^endif\s*$/i.test(line)){ push('}'); continue; }
   
-        if(m=line.match(/^for\s*\(([^;]+);([^;]+);\s*([^)]+)\)\s*$/i)){
+        m = line.match(/^for\s*\(([^;]+);([^;]+);\s*([^)]+)\)\s*$/i);
+        if(m){
           const init=convertExpr(m[1]).replace(/←/g,'=');
           const cond=convertExpr(m[2]);
           const step=convertExpr(m[3]).replace(/←/g,'=');
@@ -389,7 +400,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         }
         if(/^endfor\s*$/i.test(line)){ push('}'); continue; }
   
-        if(m=line.match(/^while\s*\((.*)\)\s*$/i)){ push(`while(${convertExpr(m[1])}){`); continue; }
+        m = line.match(/^while\s*\((.*)\)\s*$/i);
+        if(m){ push(`while(${convertExpr(m[1])}){`); continue; }
         if(/^endwhile\s*$/i.test(line)){ push('}'); continue; }
   
         // 1行に複数文（; 区切り）— forヘッダ以外


### PR DESCRIPTION
## Summary
- Refactor pseudo-language compiler to eliminate assignments within `if` conditions.
- Mirror the same changes in sandbox worker implementation.

## Testing
- `node --check pseudo/main.js`
- `node --check pseudo/sandbox-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc8358eb68832bb12f522705348f7b