### PR TITLE
Fix HTML tag display in code editor

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -961,7 +961,7 @@ A ← [10, 7, 8, 9, 1, 5]
       '整数型','実数型','文字列型','真偽値'
     ]);
 
-    function escapeHtml(str){ return str.replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
+    function escapeHtml(str){ return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
     function highlightCode(){
       const commentRegex=/\/\/.*$/gm;


### PR DESCRIPTION
## Summary
- Escape greater-than signs in editor's HTML escaping routine to prevent raw tags from rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93fc7ff0832b80460f9350c32389