### PR TITLE
Fix code editor selection to avoid span tags

### DIFF
--- a/pseudo/index.html
+++ b/pseudo/index.html
@@ -27,6 +27,7 @@
   #highlight {
     position:absolute; inset:0; margin:0; padding:12px; overflow:auto;
     white-space:pre; pointer-events:none; color:#e9f1ff;
+    user-select:none;
     font-family: inherit; font-size:14px; line-height:1.45;
   }
   #code {


### PR DESCRIPTION
## Summary
- avoid selecting highlight markup by disabling user selection on the overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc95607fbc832b98e7f0150f7166be