### PR TITLE
Fix code editor copy and line numbering

### DIFF
--- a/pseudo/index.html
+++ b/pseudo/index.html
@@ -27,12 +27,15 @@
   #highlight {
     position:absolute; inset:0; margin:0; padding:12px; overflow:auto;
     white-space:pre; pointer-events:none; color:#e9f1ff;
+    user-select:none;
     font-family: inherit; font-size:14px; line-height:1.45;
+    z-index:0;
   }
   #code {
     position:absolute; inset:0; padding:12px; border:0; outline:none; resize:none;
     background:transparent; color:transparent; caret-color:#e9f1ff;
     line-height:1.45; overflow:auto; height:100%;
+    z-index:1;
   }
   #code::placeholder { color:#556; }
   .kw { color:#4ea1ff; }
@@ -91,65 +94,7 @@
 
     <!-- 行番号付きエディタ -->
     <div id="editorWrap">
-      <div id="lineNumbers">1
-2
-3
-4
-5
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17
-18
-19
-20
-21
-22
-23
-24
-25
-26
-27
-28
-29
-30
-31
-32
-33
-34
-35
-36
-37
-38
-39
-40
-41
-42
-43
-44
-45
-46
-47
-48
-49
-50
-51
-52
-53
-54
-55
-56
-57
-58
-59</div>
+      <div id="lineNumbers"></div>
       <div id="codeWrap">
         <pre id="highlight"></pre>
         <textarea id="code" spellcheck="false" placeholder="ここに疑似言語を書きます…"></textarea>

--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -980,8 +980,9 @@ A ← [10, 7, 8, 9, 1, 5]
     }
   
     function updateLineNumbers(){
-      const lines = codeArea.value.split('\n').length || 1;
-      let buf = '1'; for(let i=2;i<=lines;i++){ buf += '\n' + i; }
+      const lines = Math.max(codeArea.value.split('\n').length, 1);
+      let buf = '';
+      for(let i=1;i<=lines;i++){ buf += (i===1?'':'\n') + i; }
       lineNumbers.textContent = buf;
     }
     function insertExample(){ const key=exampleSelect.value; const demo=getExample(key); codeArea.value=demo; updateLineNumbers(); highlightCode(); }
@@ -1000,6 +1001,13 @@ A ← [10, 7, 8, 9, 1, 5]
     //document.getElementById('btnExample').addEventListener('click', insertExample);
     exampleSelect.addEventListener('change', insertExample);
     document.addEventListener('keydown', (e)=>{ if((e.ctrlKey||e.metaKey)&&e.key==='Enter'){ run(); } });
+    codeArea.addEventListener('copy', (e)=>{
+      const start = codeArea.selectionStart;
+      const end = codeArea.selectionEnd;
+      const text = codeArea.value.substring(start, end);
+      e.clipboardData.setData('text/plain', text);
+      e.preventDefault();
+    });
     codeArea.addEventListener('input', ()=>{ updateLineNumbers(); highlightCode(); });
     codeArea.addEventListener('scroll', ()=>{ lineNumbers.scrollTop = codeArea.scrollTop; highlightArea.scrollTop = codeArea.scrollTop; });
   


### PR DESCRIPTION
## Summary
- render line numbers dynamically to remove stray leading zero
- keep syntax highlight behind editable code area and copy plain text via custom handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc95607fbc832b98e7f0150f7166be