### PR TITLE
Remove code syntax highlighting

### DIFF
--- a/pseudo/index.html
+++ b/pseudo/index.html
@@ -24,24 +24,12 @@
     min-width:3.5ch; white-space:pre; font-family: inherit; font-size:14px; line-height:1.45;
   }
   #codeWrap { position:relative; flex:1 1 auto; height:100%; }
-  #highlight {
-    position:absolute; inset:0; margin:0; padding:12px; overflow:auto;
-    white-space:pre; pointer-events:none; color:#e9f1ff;
-    user-select:none;
-    font-family: inherit; font-size:14px; line-height:1.45;
-    z-index:0;
-  }
   #code {
     position:absolute; inset:0; padding:12px; border:0; outline:none; resize:none;
-    background:transparent; color:transparent; caret-color:#e9f1ff;
+    background:#0e1630; color:#e9f1ff; caret-color:#e9f1ff;
     line-height:1.45; overflow:auto; height:100%;
-    z-index:1;
   }
   #code::placeholder { color:#556; }
-  .kw { color:#4ea1ff; }
-  .comment { color:#4cb870; }
-  .op { color:#ff6b6b; }
-  .fn { color:#c77dff; }
 
   .row { display:flex; gap:8px; padding:10px; align-items:center; flex-wrap:wrap; }
   .row .grow { flex:1 1 auto; }
@@ -96,7 +84,6 @@
     <div id="editorWrap">
       <div id="lineNumbers"></div>
       <div id="codeWrap">
-        <pre id="highlight"></pre>
         <textarea id="code" spellcheck="false" placeholder="ここに疑似言語を書きます…"></textarea>
       </div>
     </div>

--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -952,17 +952,8 @@ A ← [10, 7, 8, 9, 1, 5]
     // ========= UI =========
     const codeArea = $('#code');
     const lineNumbers = $('#lineNumbers');
-    const highlightArea = $('#highlight');
     const exampleSelect = $('#exampleSelect');
 
-    const KEYWORDS = new Set([
-      'if','elseif','else','endif','for','endfor','while','endwhile','repeat','until',
-      '反復','反復終わり','レコード型','レコード型終わり','ポインタ','新規','NIL',
-      '手続き','手続き終わり','MAIN','入力','出力','改行',
-      '整数型','実数型','文字列型','真偽値'
-    ]);
-
-    function escapeHtml(str){ return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
     // エディタ内に HTML タグが入り込んだ場合に除去する
     function sanitizeCode(){
@@ -972,30 +963,13 @@ A ← [10, 7, 8, 9, 1, 5]
       }
     }
 
-    function highlightCode(){
-      sanitizeCode();
-      const commentRegex=/\/\/.*$/gm;
-      const comments=[];
-      let tmp=codeArea.value.replace(commentRegex,m=>{ comments.push(m); return `\u0000${comments.length-1}\u0000`; });
-      tmp=escapeHtml(tmp);
-      const kwRegex=new RegExp('\\b(' + Array.from(KEYWORDS).join('|') + ')\\b','g');
-      tmp=tmp.replace(kwRegex,'<span class="kw">$1</span>');
-      // 演算子を強調表示（- は末尾に移動して解釈エラーを防ぐ）
-      tmp=tmp.replace(/([+*\/<>!=-]|←)/g,'<span class="op">$1</span>');
-      tmp=tmp.replace(/\b([A-Za-z_][A-Za-z0-9_]*|[\u3040-\u30ff\u4e00-\u9faf]+)(?=\()/g,(m)=>{
-        return KEYWORDS.has(m)?m:`<span class="fn">${m}</span>`;
-      });
-      tmp=tmp.replace(/\\u0000(\\d+)\\u0000/g,(_,i)=>`<span class="comment">${escapeHtml(comments[+i])}</span>`);
-      highlightArea.innerHTML=tmp;
-    }
-  
     function updateLineNumbers(){
       const lines = Math.max(codeArea.value.split('\n').length, 1);
       let buf = '';
       for(let i=1;i<=lines;i++){ buf += (i===1?'':'\n') + i; }
       lineNumbers.textContent = buf;
     }
-    function insertExample(){ const key=exampleSelect.value; const demo=getExample(key); codeArea.value=demo; updateLineNumbers(); highlightCode(); }
+    function insertExample(){ const key=exampleSelect.value; const demo=getExample(key); codeArea.value=demo; sanitizeCode(); updateLineNumbers(); }
   
     document.getElementById('btnRun').addEventListener('click', run);
     document.getElementById('btnClearOut').addEventListener('click', clearOutput);
@@ -1018,10 +992,9 @@ A ← [10, 7, 8, 9, 1, 5]
       e.clipboardData.setData('text/plain', text);
       e.preventDefault();
     });
-    codeArea.addEventListener('input', ()=>{ updateLineNumbers(); highlightCode(); });
-    codeArea.addEventListener('scroll', ()=>{ lineNumbers.scrollTop = codeArea.scrollTop; highlightArea.scrollTop = codeArea.scrollTop; });
+    codeArea.addEventListener('input', ()=>{ sanitizeCode(); updateLineNumbers(); });
+    codeArea.addEventListener('scroll', ()=>{ lineNumbers.scrollTop = codeArea.scrollTop; });
   
       // 初期は単方向リスト
       insertExample();
-      highlightCode();
       updateAd();


### PR DESCRIPTION
## Summary
- remove syntax highlighting overlay and styles
- simplify editor events to only sanitize input and update line numbers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bca1817da4832ba34d0bcdffc77850