### PR TITLE
Improve syntax error line reporting in sandbox worker

### DIFF
--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -437,13 +437,23 @@ self.onmessage = function(e){
     let srcLine = __LINE__ || 0;
     const stack = String(err && err.stack || '');
     let jsLine = null;
-    let m = stack.match(/worker_pseudo\.js:(\d+):\d+/) || stack.match(/\(worker_pseudo\.js:(\d+):\d+\)/) || stack.match(/<anonymous>:(\d+):\d+/);
-    if (m) jsLine = parseInt(m[1], 10);
+    let offset = 0;
+    let m = stack.match(/worker_pseudo\.js:(\d+):\d+/);
+    if (m) { jsLine = parseInt(m[1], 10); offset = 1; }
+    if (!m) {
+      m = stack.match(/\(worker_pseudo\.js:(\d+):\d+\)/);
+      if (m) { jsLine = parseInt(m[1], 10); offset = 1; }
+    }
+    if (!m) {
+      m = stack.match(/<anonymous>:(\d+):\d+/) || stack.match(/\[eval\]:(\d+):\d+/);
+      if (m) { jsLine = parseInt(m[1], 10); }
+    }
     if (!jsLine && (err.lineNumber || err.line)) {
       jsLine = parseInt(err.lineNumber || err.line, 10);
     }
     if (Number.isInteger(jsLine) && jsLine > 0) {
-      const mapped = __jsLineToPseudo(jsLine);
+      let mapped = __jsLineToPseudo(jsLine - offset);
+      if (!mapped) mapped = __jsLineToPseudo(jsLine);
       if (mapped) srcLine = mapped;
     }
     const srcText = (__SRC_LINES && __SRC_LINES[srcLine-1]!==undefined) ? __SRC_LINES[srcLine-1] : '';


### PR DESCRIPTION
## Summary
- Parse eval and <anonymous> stack traces without applying prelude offset
- Fallback to mapping both shifted and unshifted JS lines to avoid line 0 reports

## Testing
- `npm test` *(fails: enoent: no such file or directory, open '/workspace/cogproject.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bca3ec4b90832b8324732489cd36d2