### PR TITLE
Fix missing brace in sandbox worker error handler

### DIFF
--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -456,7 +456,8 @@ self.onmessage = function(e){
     if (Number.isInteger(jsLine) && jsLine > 0) {
       let mapped = __jsLineToPseudo(jsLine - offset);
       if (!mapped) mapped = __jsLineToPseudo(jsLine);
-
+      if (mapped) srcLine = mapped;
+    }
     const srcText = (__SRC_LINES && __SRC_LINES[srcLine-1]!==undefined) ? __SRC_LINES[srcLine-1] : '';
     self.postMessage({type:'error', line: srcLine, message: err.message, sourceLine: srcText});
   }


### PR DESCRIPTION
## Summary
- prevent syntax error by closing missing brace and mapping source line in sandbox worker

## Testing
- `node --check pseudo/sandbox-worker.js && node --check pseudo/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bcae120b18832b94aca1f7054c5b9b