### PR TITLE
Fix missing brace in sandbox worker error handler

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -417,17 +417,13 @@ function resetInput(){
       // MAIN 自動実行
       let curBak=curLine; curLine=0; push(`if (typeof MAIN === 'function'){ MAIN(); }`); curLine=curBak;
   
-      // マッピング公開
+      // マッピング公開と生成JSの保持
       window.__LINE_MAP = map;
-  
- 
-// マッピング公開と生成JSの保持（★追加）
-window.__LINE_MAP = map;
-const joined = out.join('\n');
-window.__LAST_JS = joined;
+      const joined = out.join('\n');
+      window.__LAST_JS = joined;
 
-// 連結して返す
-return joined;
+      // 連結して返す
+      return joined;
     }
   
     // ========= 実行器（構文/実行時の行番号を逆引き） =========
@@ -828,7 +824,7 @@ A ← [10, 7, 8, 9, 1, 5]
         // Lomuto 方式
         pivot ← A[r]
         i ← l - 1
-        for (j ← l; j <= r - 1; j ← j + 1)
+        for (j ← l; j < r; j ← j + 1)
             if (A[j] <= pivot)
                 i ← i + 1
                 tmp ← A[i]; A[i] ← A[j]; A[j] ← tmp
@@ -959,7 +955,8 @@ A ← [10, 7, 8, 9, 1, 5]
 
     // エディタ内に HTML タグが入り込んだ場合に除去する
     function sanitizeCode(){
-      const cleaned = codeArea.value.replace(/<[^>]*>/g, '');
+      // Remove HTML tags while preserving comparison operators like '<' and '>'
+      const cleaned = codeArea.value.replace(/<\/?[A-Za-z][^>]*>/g, '');
       if (cleaned !== codeArea.value) {
         codeArea.value = cleaned;
       }

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -411,17 +411,13 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
       // MAIN 自動実行
       let curBak=curLine; curLine=0; push(`if (typeof MAIN === 'function'){ MAIN(); }`); curLine=curBak;
   
-      // マッピング公開
+      // マッピング公開と生成JSの保持
       __LINE_MAP = map;
-  
- 
-// マッピング公開と生成JSの保持（★追加）
-__LINE_MAP = map;
-const joined = out.join('\n');
-__LAST_JS = joined;
+      const joined = out.join('\n');
+      __LAST_JS = joined;
 
-// 連結して返す
-return joined;
+      // 連結して返す
+      return joined;
     }
   
     // ========= 実行器（構文/実行時の行番号を逆引き） =========
@@ -456,7 +452,8 @@ self.onmessage = function(e){
     if (Number.isInteger(jsLine) && jsLine > 0) {
       let mapped = __jsLineToPseudo(jsLine - offset);
       if (!mapped) mapped = __jsLineToPseudo(jsLine);
-
+      if (mapped) srcLine = mapped;
+    }
     const srcText = (__SRC_LINES && __SRC_LINES[srcLine-1]!==undefined) ? __SRC_LINES[srcLine-1] : '';
     self.postMessage({type:'error', line: srcLine, message: err.message, sourceLine: srcText});
   }


### PR DESCRIPTION
## Summary
- remove duplicate line-map assignments and capture generated code for reliable line mapping
- use strict less-than in quick sort loop to ensure proper iteration
- strip only HTML tags in editor to preserve comparison operators in code examples

## Testing
- `node --check pseudo/main.js`
- `node --check pseudo/sandbox-worker.js`
- `node - <<'NODE'\nfunction sanitOld(s){return s.replace(/<[^>]*>/g,'');}\nfunction sanitNew(s){return s.replace(/<\\/?[A-Za-z][^>]*>/g,'');}\nconst code='for (k \u2190 0; k < A.length; k \u2190 k + 1)\n    if (A[i] > A[i+1])';\nconsole.log('old:', sanitOld(code));\nconsole.log('new:', sanitNew(code));\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_68bcae120b18832b94aca1f7054c5b9b