### PR TITLE
Fix line number mapping for pseudocode errors

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -136,7 +136,8 @@ function resetInput(){
         .replace(/[＋]/g,'+').replace(/[－]/g,'-').replace(/[×＊]/g,'*').replace(/[÷／]/g,'/')
         .replace(/[「]/g,'"').replace(/[」]/g,'"')
         .replace(/[　]/g,' ').replace(/\t/g,'  ').replace(/[\u00A0]/g,' ')
-        .replace(/\s+$/gm,'');
+        // preserve blank lines by trimming only spaces and tabs at line ends
+        .replace(/[ \t]+$/gm,'');
     }
     function convertExpr(expr){
       return expr

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -130,7 +130,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         .replace(/[＋]/g,'+').replace(/[－]/g,'-').replace(/[×＊]/g,'*').replace(/[÷／]/g,'/')
         .replace(/[「]/g,'"').replace(/[」]/g,'"')
         .replace(/[　]/g,' ').replace(/\t/g,'  ').replace(/[\u00A0]/g,' ')
-        .replace(/\s+$/gm,'');
+        // preserve blank lines by trimming only spaces and tabs at line ends
+        .replace(/[ \t]+$/gm,'');
     }
     function convertExpr(expr){
       return expr


### PR DESCRIPTION
## Summary
- preserve blank lines during normalization to keep source and error line numbers aligned
- update both browser and worker scripts

## Testing
- `node --check pseudo/main.js`
- `node --check pseudo/sandbox-worker.js`
- manually compiled sample code verifying error line maps to source line 17

------
https://chatgpt.com/codex/tasks/task_e_68bcbeabdfe8832b84f1aefb30a331af