### PR TITLE
Fix line number mapping for pseudocode errors

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -136,7 +136,8 @@ function resetInput(){
         .replace(/[＋]/g,'+').replace(/[－]/g,'-').replace(/[×＊]/g,'*').replace(/[÷／]/g,'/')
         .replace(/[「]/g,'"').replace(/[」]/g,'"')
         .replace(/[　]/g,' ').replace(/\t/g,'  ').replace(/[\u00A0]/g,' ')
-        .replace(/\s+$/gm,'');
+        // preserve blank lines by trimming only spaces and tabs at line ends
+        .replace(/[ \t]+$/gm,'');
     }
     function convertExpr(expr){
       return expr

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -130,7 +130,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         .replace(/[＋]/g,'+').replace(/[－]/g,'-').replace(/[×＊]/g,'*').replace(/[÷／]/g,'/')
         .replace(/[「]/g,'"').replace(/[」]/g,'"')
         .replace(/[　]/g,' ').replace(/\t/g,'  ').replace(/[\u00A0]/g,' ')
-        .replace(/\s+$/gm,'');
+        // preserve blank lines by trimming only spaces and tabs at line ends
+        .replace(/[ \t]+$/gm,'');
     }
     function convertExpr(expr){
       return expr
@@ -452,7 +453,7 @@ self.onmessage = function(e){
     if (Number.isInteger(jsLine) && jsLine > 0) {
       let mapped = __jsLineToPseudo(jsLine - offset);
       if (!mapped) mapped = __jsLineToPseudo(jsLine);
-      if (mapped) srcLine = mapped;
+      if (mapped && !srcLine) srcLine = mapped;
     }
     const srcText = (__SRC_LINES && __SRC_LINES[srcLine-1]!==undefined) ? __SRC_LINES[srcLine-1] : '';
     self.postMessage({type:'error', line: srcLine, message: err.message, sourceLine: srcText});


### PR DESCRIPTION
## Summary
- preserve blank lines during normalization to keep source and error line numbers aligned
- avoid overriding runtime line info with stack mapping to prevent off-by-one errors

## Testing
- `node --check pseudo/main.js`
- `node --check pseudo/sandbox-worker.js`
- manual worker run verifying runtime error reports line 17 for `found ← fals`


------
https://chatgpt.com/codex/tasks/task_e_68bcbeabdfe8832b84f1aefb30a331af