### PR TITLE
Fix line number mapping for pseudocode errors

### DIFF
--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -136,7 +136,8 @@ function resetInput(){
         .replace(/[＋]/g,'+').replace(/[－]/g,'-').replace(/[×＊]/g,'*').replace(/[÷／]/g,'/')
         .replace(/[「]/g,'"').replace(/[」]/g,'"')
         .replace(/[　]/g,' ').replace(/\t/g,'  ').replace(/[\u00A0]/g,' ')
-        .replace(/\s+$/gm,'');
+        // preserve blank lines by trimming only spaces and tabs at line ends
+        .replace(/[ \t]+$/gm,'');
     }
     function convertExpr(expr){
       return expr
@@ -295,6 +296,12 @@ function resetInput(){
         let raw=lines[i];
         const cpos=raw.indexOf('//'); if(cpos!==-1) raw=raw.slice(0,cpos);
         const line=raw.trim();
+        const parenCheck = raw.replace(/".*?"|'.*?'/g,'');
+        let bal=0; let bad=false;
+        for(const ch of parenCheck){
+          if(ch==='(') bal++; else if(ch===')'){ if(bal) bal--; else { bad=true; break; } }
+        }
+        if(bal>0 || bad){ const e=new Error(bad? 'unexpected )' : 'missing ) after argument list'); e.line=curLine; throw e; }
   
         // 空行/コメント行：マークだけ（JS 1行、map 1件）
         if(!line){ out.push(`__mark(${curLine});`); map.push(curLine); continue; }

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -130,7 +130,8 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         .replace(/[＋]/g,'+').replace(/[－]/g,'-').replace(/[×＊]/g,'*').replace(/[÷／]/g,'/')
         .replace(/[「]/g,'"').replace(/[」]/g,'"')
         .replace(/[　]/g,' ').replace(/\t/g,'  ').replace(/[\u00A0]/g,' ')
-        .replace(/\s+$/gm,'');
+        // preserve blank lines by trimming only spaces and tabs at line ends
+        .replace(/[ \t]+$/gm,'');
     }
     function convertExpr(expr){
       return expr
@@ -289,6 +290,12 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         let raw=lines[i];
         const cpos=raw.indexOf('//'); if(cpos!==-1) raw=raw.slice(0,cpos);
         const line=raw.trim();
+        const parenCheck = raw.replace(/".*?"|'.*?'/g,'');
+        let bal=0; let bad=false;
+        for(const ch of parenCheck){
+          if(ch==='(') bal++; else if(ch===')'){ if(bal) bal--; else { bad=true; break; } }
+        }
+        if(bal>0 || bad){ const e=new Error(bad? 'unexpected )' : 'missing ) after argument list'); e.line=curLine; throw e; }
   
         // 空行/コメント行：マークだけ（JS 1行、map 1件）
         if(!line){ out.push(`__mark(${curLine});`); map.push(curLine); continue; }
@@ -433,6 +440,7 @@ self.onmessage = function(e){
     self.postMessage({type:'done'});
   }catch(err){
     let srcLine = __LINE__ || 0;
+    if (!srcLine && err && err.line) srcLine = parseInt(err.line, 10) || 0;
     const stack = String(err && err.stack || '');
     let jsLine = null;
     let offset = 0;
@@ -447,13 +455,16 @@ self.onmessage = function(e){
       if (m) { jsLine = parseInt(m[1], 10); }
     }
     if (!jsLine && (err.lineNumber || err.line)) {
-      jsLine = parseInt(err.lineNumber || err.line, 10);
+      const tmp = parseInt(err.lineNumber || err.line, 10);
+      const jsLines = (__LAST_JS && __LAST_JS.split('\n').length) || 0;
+      if (tmp > 0 && tmp <= jsLines + 1) jsLine = tmp;
     }
     if (Number.isInteger(jsLine) && jsLine > 0) {
       let mapped = __jsLineToPseudo(jsLine - offset);
       if (!mapped) mapped = __jsLineToPseudo(jsLine);
-      if (mapped) srcLine = mapped;
+      if (mapped && !srcLine) srcLine = mapped;
     }
+    if (!srcLine) srcLine = 1;
     const srcText = (__SRC_LINES && __SRC_LINES[srcLine-1]!==undefined) ? __SRC_LINES[srcLine-1] : '';
     self.postMessage({type:'error', line: srcLine, message: err.message, sourceLine: srcText});
   }


### PR DESCRIPTION
## Summary
- preserve blank lines during normalization to keep source and error line numbers aligned
- avoid overriding runtime line info with stack mapping to prevent off-by-one errors
- detect unmatched parentheses during compilation to surface accurate syntax error lines

## Testing
- `node --check pseudo/main.js`
- `node --check pseudo/sandbox-worker.js`
- `node` worker run with unmatched parenthesis reports line 25 for `出力(p.data`


------
https://chatgpt.com/codex/tasks/task_e_68bcbeabdfe8832b84f1aefb30a331af