### PR TITLE
feat: add 関数/function keywords

### DIFF
--- a/pseudo/index.html
+++ b/pseudo/index.html
@@ -104,7 +104,7 @@
 
     <div class="footer small">
       対応: 変数宣言（<code class="kbd">整数型/実数型/文字列型/真偽値</code> / 配列 <code class="kbd">x{}</code>）、<code class="kbd">入力(a,b)</code>、<code class="kbd">出力(...)</code>、<code class="kbd">改行()</code>、<code class="kbd">if/elseif/else/endif</code>（thenなし）、<code class="kbd">for/endfor</code>、<code class="kbd">while/endwhile</code>、<code class="kbd">repeat/until</code>、<code class="kbd">反復(cond)/反復終わり</code>、代入<code class="kbd">←</code>。<br>
-      追加: <code class="kbd">レコード型 T ... レコード型終わり</code>、<code class="kbd">T ポインタ x</code>、<code class="kbd">新規 T</code>、<code class="kbd">NIL</code>、<code class="kbd">手続き NAME(…)/手続き終わり</code>（<code class="kbd">MAIN()</code> 自動実行）。<br>
+      追加: <code class="kbd">レコード型 T ... レコード型終わり</code>、<code class="kbd">T ポインタ x</code>、<code class="kbd">新規 T</code>、<code class="kbd">NIL</code>、<code class="kbd">手続き NAME(…)/手続き終わり</code>、<code class="kbd">関数 NAME(…)/関数終わり</code>（<code class="kbd">MAIN()</code> 自動実行）。<br>
       エラー時は擬似言語の行番号と該当行を表示。
     </div>
   </section>

--- a/pseudo/main.js
+++ b/pseudo/main.js
@@ -340,16 +340,16 @@ function resetInput(){
         }
         if(inRecord){ const f=parseFieldKind(line); if(f){ recordDefs[currentRecord].fields[f.name]=f.kind; } continue; }
   
-        // 手続き（プロシージャ）開始: 「手続き NAME(...)」または「procedure NAME(...)」
-        if(m = line.match(/^(?:手続き|procedure)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i)){
+        // 手続き/関数開始: 「手続き NAME(...)」「procedure NAME(...)」「関数 NAME(...)」または「function NAME(... )」
+        if(m = line.match(/^(?:手続き|procedure|関数|function)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i)){
           const name = m[1];
           const paramStr = m[2];
           push(`function ${name}(){`);
           parseProcParams(paramStr);
           continue;
         }
-        // 手続き（プロシージャ）終了: 「手続き終わり」または「end procedure」
-        if(/^(?:手続き終わり|end\s*procedure)\s*$/i.test(line)){
+        // 手続き/関数終了: 「手続き終わり」「関数終わり」または「end procedure/end function」
+        if(/^(?:手続き終わり|関数終わり|end\s*(?:procedure|function))\s*$/i.test(line)){
           push('}');
           continue;
         }

--- a/pseudo/manual.html
+++ b/pseudo/manual.html
@@ -39,7 +39,7 @@
     <li><code>レコード型 T ... レコード型終わり</code></li>
     <li><code>T ポインタ x</code> と <code>新規 T</code> による動的メモリ</li>
     <li><code>NIL</code> 値</li>
-    <li><code>手続き NAME(...)/手続き終わり</code>、<code>MAIN()</code> の自動実行</li>
+    <li><code>手続き NAME(...)/手続き終わり</code>、<code>関数 NAME(...)/関数終わり</code>、<code>MAIN()</code> の自動実行</li>
   </ul>
 
   <p>エラーが発生した場合は、行番号と該当行が表示されます。詳しくはインタープリターのソースコードを参照してください。</p>

--- a/pseudo/sandbox-worker.js
+++ b/pseudo/sandbox-worker.js
@@ -334,16 +334,16 @@ function resetInput(tokens){ inputTokens = (tokens || []).slice(); }
         }
         if(inRecord){ const f=parseFieldKind(line); if(f){ recordDefs[currentRecord].fields[f.name]=f.kind; } continue; }
   
-        // 手続き（プロシージャ）開始: 「手続き NAME(...)」または「procedure NAME(...)」
-        if(m = line.match(/^(?:手続き|procedure)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i)){
+        // 手続き/関数開始: 「手続き NAME(...)」「procedure NAME(...)」「関数 NAME(...)」または「function NAME(... )」
+        if(m = line.match(/^(?:手続き|procedure|関数|function)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\((.*)\)\s*$/i)){
           const name = m[1];
           const paramStr = m[2];
           push(`function ${name}(){`);
           parseProcParams(paramStr);
           continue;
         }
-        // 手続き（プロシージャ）終了: 「手続き終わり」または「end procedure」
-        if(/^(?:手続き終わり|end\s*procedure)\s*$/i.test(line)){
+        // 手続き/関数終了: 「手続き終わり」「関数終わり」または「end procedure/end function」
+        if(/^(?:手続き終わり|関数終わり|end\s*(?:procedure|function))\s*$/i.test(line)){
           push('}');
           continue;
         }


### PR DESCRIPTION
## Summary
- allow using `関数`/`function` and matching end keywords in pseudo code
- document function aliases in docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfd90c874832bbc1de52356eb2a2a